### PR TITLE
feat(command-line): add input from command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # alien_invasion
 
-go run $(ls -1 *.go | grep -v _test.go)
+go  run $(ls -1 *.go | grep -v _test.go) -aliens 5

--- a/city_data.go
+++ b/city_data.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 )
 
-var CacheCityNamesFromInput map[string]bool
+var CacheCityNamesFromInput map[string]bool = make(map[string]bool)
 
 type CityData struct {
 	Name        string
@@ -24,7 +24,6 @@ func NewCityData(line string) CityData {
 
 	cityData.Name = cityName
 	cityData.Connections = make([]Connection, len(cityConnections))
-	CacheCityNamesFromInput = make(map[string]bool)
 	CacheCityNamesFromInput[cityData.Name] = true
 
 	for index := range cityData.Connections {

--- a/main.go
+++ b/main.go
@@ -1,16 +1,21 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"strconv"
 	"strings"
 )
 
 func main() {
+	var alienCount = flag.Int("aliens", 3, "number of aliens to randomly place in cities")
+
+	flag.Parse()
+
 	worldMap := NewWorldMap()
 	lines := FileReader("cities.txt")
 	worldMap.LoadCities(lines)
-	worldMap.LoadAliens(5)
+	worldMap.LoadAliens(*alienCount)
 
 	simulate(worldMap)
 

--- a/world_map.go
+++ b/world_map.go
@@ -37,7 +37,6 @@ func (world *WorldMap) RemoveCity(name string) bool {
 
 func (world *WorldMap) LoadCities(lines []string) {
 	for _, line := range lines {
-
 		cityData := NewCityData(line)
 
 		var currentCity *City


### PR DESCRIPTION
Add ability to add number of aliens from command line
using -aliens flag.

ex) go run main.go  -aliens 10

Fixed output format global CacheCityNamesFromInput was
not being reference instead overwritten on each iteration.